### PR TITLE
support more tensor dtype other than FP32.

### DIFF
--- a/gpu_mem_track.py
+++ b/gpu_mem_track.py
@@ -21,7 +21,7 @@ def get_mem_space(x):
     try:
         ret = dtype_memory_size_dict[x]
     except KeyError:
-        print("dtype {x} is not supported!")
+        print(f"dtype {x} is not supported!")
     return ret
 
 class MemTracker(object):


### PR DESCRIPTION
Correctly Display  Memory Usage for Tensor dtype other than torch.float32.